### PR TITLE
chore: fix bullmq queue name and exclude graphify-out from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+graphify-out/** linguist-vendored

--- a/apps/worker/src/queues/heartbeat.queue.ts
+++ b/apps/worker/src/queues/heartbeat.queue.ts
@@ -1,7 +1,7 @@
 import { Queue } from 'bullmq';
 import { getRedisConnectionOptions } from '../connection.js';
 
-export const HEARTBEAT_QUEUE_NAME = 'system:heartbeat';
+export const HEARTBEAT_QUEUE_NAME = 'system-heartbeat';
 
 export interface HeartbeatJobData {
   emittedAt: string;


### PR DESCRIPTION
## Summary
- Rename BullMQ queue `system:heartbeat` → `system-heartbeat` — BullMQ v5 no longer allows colons in queue names, causing worker to crash on startup
- Add `.gitattributes` to mark `graphify-out/` as vendored so GitHub language stats correctly show TypeScript instead of HTML

## Changes
- **`apps/worker/src/queues/heartbeat.queue.ts`**: rename queue name constant
- **`.gitattributes`**: exclude `graphify-out/**` from linguist language detection

## Verification
- ✅ `pnpm lint` — 0 errors
- ✅ `pnpm typecheck` — 0 errors
- ✅ `pnpm test` — Tests passing
- ✅ `pnpm dev:worker` — Worker starts and processes heartbeat job successfully