### PR TITLE
feat: implement public per-organization api key system (Issue #19)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { healthRouter } from './routes/health.js';
 import { webhooksRouter, type CustomRequest } from './routes/webhooks.js';
 import { knowledgeSourcesRouter } from './routes/knowledge-sources.js';
 import { chatRouter, conversationsRouter } from './routes/chat.js';
+import { orgRouter } from './routes/organizations.js';
 
 export function createApp(): Express {
   const app = express();
@@ -34,6 +35,7 @@ export function createApp(): Express {
   app.use('/knowledge-sources', knowledgeSourcesRouter);
   app.use('/chat', chatRouter);
   app.use('/conversations', conversationsRouter);
+  app.use('/organizations', orgRouter);
 
   return app;
 }

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -144,13 +144,27 @@ ${contextBlock}`;
 // POST /chat
 chatRouter.post(
   '/',
-  requireOrgAuth,
   async (req: Request, res: Response) => {
-    const { orgSlug, orgId } = getAuth(req);
+    let org;
 
-    if (!orgSlug) {
-      res.status(403).json({ error: 'No active organization selected' });
-      return;
+    // Check for public API key first (Widget access)
+    const publicApiKey = req.headers['x-org-key'] as string;
+    if (publicApiKey) {
+      org = await prisma.organization.findUnique({
+        where: { publicApiKey },
+      });
+      if (!org) {
+        res.status(401).json({ error: 'Invalid API key' });
+        return;
+      }
+    } else {
+      // Fallback to Clerk Auth (Dashboard access)
+      const { userId, orgSlug, orgId } = getAuth(req);
+      if (!userId || !orgSlug) {
+        res.status(401).json({ error: 'Unauthorized or no active organization' });
+        return;
+      }
+      org = await getOrUpsertOrg(orgSlug, orgId ?? null);
     }
 
     const { message, conversationId } = req.body as {
@@ -162,8 +176,6 @@ chatRouter.post(
       res.status(400).json({ error: 'message is required' });
       return;
     }
-
-    const org = await getOrUpsertOrg(orgSlug, orgId ?? null);
 
     // Get or create conversation
     let conversation;

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -1,0 +1,49 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { getAuth } from '@clerk/express';
+import { prisma } from '@app/database';
+import crypto from 'crypto';
+
+export const orgRouter: Router = Router();
+
+function requireOrgAuth(req: Request, res: Response, next: NextFunction): void {
+  const { userId, orgSlug } = getAuth(req);
+  if (!userId || !orgSlug) {
+    res.status(401).json({ error: 'Unauthorized or no active organization' });
+    return;
+  }
+  next();
+}
+
+orgRouter.use(requireOrgAuth);
+
+// GET /organizations/api-key
+orgRouter.get('/api-key', async (req: Request, res: Response) => {
+  const { orgSlug } = getAuth(req);
+  const org = await prisma.organization.findUnique({
+    where: { slug: orgSlug as string },
+    select: { publicApiKey: true },
+  });
+
+  if (!org) {
+    res.status(404).json({ error: 'Organization not found' });
+    return;
+  }
+
+  res.json({ publicApiKey: org.publicApiKey });
+});
+
+// POST /organizations/api-key/generate
+orgRouter.post('/api-key/generate', async (req: Request, res: Response) => {
+  const { orgSlug } = getAuth(req);
+  
+  // Generate a random API key (e.g., ai_live_xxxxxxxxxxxxxxxx)
+  const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
+
+  const updatedOrg = await prisma.organization.update({
+    where: { slug: orgSlug as string },
+    data: { publicApiKey: newKey },
+    select: { publicApiKey: true },
+  });
+
+  res.json({ publicApiKey: updatedOrg.publicApiKey });
+});

--- a/packages/database/prisma/migrations/20260802142600_add_public_api_key/migration.sql
+++ b/packages/database/prisma/migrations/20260802142600_add_public_api_key/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "publicApiKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organizations_publicApiKey_key" ON "organizations"("publicApiKey");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -16,12 +16,13 @@ datasource db {
 /// A client business using the platform. Every other tenant-scoped
 /// model hangs off Organization so data between clients never mixes.
 model Organization {
-  id        String   @id @default(cuid())
-  name      String
-  slug      String   @unique
-  plan      OrganizationPlan @default(FREE)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id           String   @id @default(cuid())
+  name         String
+  slug         String   @unique
+  publicApiKey String?  @unique
+  plan         OrganizationPlan @default(FREE)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   memberships     Membership[]
   knowledgeSources KnowledgeSource[]


### PR DESCRIPTION
## Changes
- **Database:** Added \publicApiKey\ column to \Organization\ model to store the organization's widget access token.
- **Backend API:** Created new router \/organizations/api-key\ and \/organizations/api-key/generate\ to allow owners to retrieve and rotate their key.
- **Chat Endpoint:** Updated \POST /chat\ to prioritize \x-org-key\ header authentication for incoming widget queries, gracefully falling back to Clerk session auth for internal dashboard chats.

## Checklist
- [x] Database migration created and deployed
- [x] API routes verified
- [x] Unauthenticated widget bypass successfully implemented