### PR TITLE
fix: auto-create organization on API key generation

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -18,30 +18,37 @@ orgRouter.use(requireOrgAuth);
 
 // GET /organizations/api-key
 orgRouter.get('/api-key', async (req: Request, res: Response) => {
-  const { orgSlug } = getAuth(req);
-  const org = await prisma.organization.findUnique({
-    where: { slug: orgSlug as string },
-    select: { publicApiKey: true },
-  });
-
-  if (!org) {
-    res.status(404).json({ error: 'Organization not found' });
+  const { orgSlug, orgId } = getAuth(req);
+  if (!orgSlug) {
+    res.status(400).json({ error: 'Missing orgSlug' });
     return;
   }
+  
+  const org = await prisma.organization.upsert({
+    where: { slug: orgSlug as string },
+    create: { slug: orgSlug as string, name: orgId ?? orgSlug as string },
+    update: {},
+    select: { publicApiKey: true },
+  });
 
   res.json({ publicApiKey: org.publicApiKey });
 });
 
 // POST /organizations/api-key/generate
 orgRouter.post('/api-key/generate', async (req: Request, res: Response) => {
-  const { orgSlug } = getAuth(req);
+  const { orgSlug, orgId } = getAuth(req);
+  if (!orgSlug) {
+    res.status(400).json({ error: 'Missing orgSlug' });
+    return;
+  }
   
   // Generate a random API key (e.g., ai_live_xxxxxxxxxxxxxxxx)
   const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
 
-  const updatedOrg = await prisma.organization.update({
+  const updatedOrg = await prisma.organization.upsert({
     where: { slug: orgSlug as string },
-    data: { publicApiKey: newKey },
+    create: { slug: orgSlug as string, name: orgId ?? orgSlug as string, publicApiKey: newKey },
+    update: { publicApiKey: newKey },
     select: { publicApiKey: true },
   });
 


### PR DESCRIPTION
## Overview
This PR fixes a bug where new organizations could not generate an API key because their organization record didn't exist in the database yet.

## Changes Made
- **API Router (`apps/api/src/routes/organizations.ts`)**:
  - Replaced `prisma.organization.findUnique` and `prisma.organization.update` with `prisma.organization.upsert` to automatically create the organization record if it does not exist when accessing or generating the API key.

## Testing Performed
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
