### PR TITLE
fix: fallback undefined api url to localhost:4000 in frontend components

### DIFF
--- a/apps/web/src/components/dashboard/ApiKeyManager.tsx
+++ b/apps/web/src/components/dashboard/ApiKeyManager.tsx
@@ -18,7 +18,8 @@ export function ApiKeyManager() {
     setIsLoading(true);
     try {
       const token = await getToken();
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/organizations/api-key`, {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+      const res = await fetch(`${apiUrl}/organizations/api-key`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -38,7 +39,8 @@ export function ApiKeyManager() {
     setIsLoading(true);
     try {
       const token = await getToken();
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/organizations/api-key/generate`, {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+      const res = await fetch(`${apiUrl}/organizations/api-key/generate`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Overview
This PR fixes a bug where `process.env.NEXT_PUBLIC_API_URL` is undefined in the frontend `ApiKeyManager` component, causing the API requests to fail with a 404 (relative URL routing).

## Changes Made
- **API Key Manager (`apps/web/src/components/dashboard/ApiKeyManager.tsx`)**:
  - Added a fallback to `http://localhost:4000` for both GET and POST requests so it works out of the box locally even if the `.env` variable isn't fully bound to the browser.

## Testing Performed
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
