### PR TITLE
feat: mask api key and add generation modal

### DIFF
--- a/apps/web/src/components/dashboard/ApiKeyManager.tsx
+++ b/apps/web/src/components/dashboard/ApiKeyManager.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@clerk/nextjs';
-import { Copy, Check, Key, RefreshCw } from 'lucide-react';
+import { Copy, Check, Key, RefreshCw, Eye, EyeOff, X } from 'lucide-react';
 
 export function ApiKeyManager() {
   const { getToken } = useAuth();
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCopied, setIsCopied] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [showKey, setShowKey] = useState(false);
 
   useEffect(() => {
     fetchApiKey();
@@ -49,6 +51,7 @@ export function ApiKeyManager() {
       if (res.ok) {
         const data = await res.json();
         setApiKey(data.publicApiKey);
+        setShowModal(true);
       }
     } catch (error) {
       console.error('Failed to generate API key', error);
@@ -103,15 +106,28 @@ export function ApiKeyManager() {
         <div className="space-y-4">
           <div className="relative">
             <pre className="overflow-x-auto rounded-lg border border-neutral-800 bg-neutral-950 p-4 text-sm text-neutral-300">
-              <code>{`<script src="http://localhost:3000/widget.js" data-org-key="${apiKey}"></script>`}</code>
+              <code>
+                {`<script src="http://localhost:3000/widget.js" data-org-key="${
+                  showKey ? apiKey : apiKey.substring(0, 12) + '...' + apiKey.substring(apiKey.length - 4)
+                }"></script>`}
+              </code>
             </pre>
-            <button
-              onClick={copyToClipboard}
-              className="absolute right-2 top-2 rounded-md bg-neutral-800 p-2 text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-white"
-              title="Copy snippet"
-            >
-              {isCopied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
-            </button>
+            <div className="absolute right-2 top-2 flex gap-2">
+              <button
+                onClick={() => setShowKey(!showKey)}
+                className="rounded-md bg-neutral-800 p-2 text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-white"
+                title={showKey ? "Hide API Key" : "Show API Key"}
+              >
+                {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+              <button
+                onClick={copyToClipboard}
+                className="rounded-md bg-neutral-800 p-2 text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-white"
+                title="Copy snippet"
+              >
+                {isCopied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+              </button>
+            </div>
           </div>
           
           <div className="flex justify-end">
@@ -122,6 +138,49 @@ export function ApiKeyManager() {
               <RefreshCw className="h-4 w-4" />
               Regenerate Key
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* Modal Popup */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="w-full max-w-2xl rounded-xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-medium text-white">Your New API Key is Ready!</h3>
+              <button
+                onClick={() => setShowModal(false)}
+                className="text-neutral-400 hover:text-white"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            
+            <p className="mb-6 text-sm text-neutral-400">
+              Copy the snippet below and paste it just before the closing <code>&lt;/body&gt;</code> tag of your website to embed the AI widget.
+            </p>
+            
+            <div className="relative mb-6">
+              <pre className="overflow-x-auto rounded-lg border border-neutral-800 bg-neutral-950 p-4 text-sm text-neutral-300">
+                <code>{`<script src="http://localhost:3000/widget.js" data-org-key="${apiKey}"></script>`}</code>
+              </pre>
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setShowModal(false)}
+                className="rounded-lg border border-neutral-700 px-4 py-2 text-sm font-medium text-neutral-300 hover:bg-neutral-800"
+              >
+                Close
+              </button>
+              <button
+                onClick={copyToClipboard}
+                className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              >
+                {isCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                {isCopied ? 'Copied!' : 'Copy Snippet'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/test-widget.html
+++ b/test-widget.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test AI Widget</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        margin: 0;
+        padding: 40px;
+        background-color: #f3f4f6;
+      }
+      .content {
+        max-width: 800px;
+        margin: 0 auto;
+        background: white;
+        padding: 40px;
+        border-radius: 12px;
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <h1>Testing My AI Widget 🚀</h1>
+      <p>
+        This is a dummy website. Look at the bottom right corner of this page to see the widget in
+        action!
+      </p>
+      <p>
+        Make sure your Next.js frontend (port 3000) and API (port 8000) are running via
+        <code>pnpm dev</code>.
+      </p>
+    </div>
+
+    <!-- Ini script yang barusan kita bikin! Ganti data-org-key dengan API Key mu dari halaman Settings Dashboard -->
+    <script
+      src="http://localhost:3000/widget.js"
+      data-org-key="ai_live_1e277849f3e5e802a8818c3db995dbc8ea1ed7da8e504186"
+    ></script>
+  </body>
+</html>


### PR DESCRIPTION
## Overview
This PR improves the UX and security of the API Key Manager in the settings dashboard and adds a testing file.

## Changes Made
- **API Key Manager (`apps/web/src/components/dashboard/ApiKeyManager.tsx`)**:
  - Masked the API key in the main settings view by default (e.g., `ai_live_1234...abcd`) to prevent shoulder surfing.
  - Added a toggle button (eye icon) to reveal/hide the full snippet.
  - Implemented a modal popup that appears immediately after successfully generating a new API key, making it highly visible and easy to copy.
- **Testing Utility (`test-widget.html`)**:
  - Added a dummy HTML file at the project root for local testing of the chat widget by other developers.

## Testing Performed
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
