### PR TITLE
fix: auto-generate public api key on org creation (Issue #19)

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -4,6 +4,7 @@ import OpenAI from 'openai';
 import { Pinecone } from '@pinecone-database/pinecone';
 import { prisma } from '@app/database';
 import { getEnv } from '@app/shared';
+import crypto from 'crypto';
 
 export const chatRouter: Router = Router();
 export const conversationsRouter: Router = Router();
@@ -18,11 +19,12 @@ function requireOrgAuth(req: Request, res: Response, next: NextFunction): void {
 }
 
 async function getOrUpsertOrg(orgSlug: string, orgId: string | null) {
-  return prisma.organization.upsert({
-    where: { slug: orgSlug },
-    create: { slug: orgSlug, name: orgId ?? orgSlug },
-    update: {},
-  });
+    const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
+    return prisma.organization.upsert({
+      where: { slug: orgSlug },
+      create: { slug: orgSlug, name: orgId ?? orgSlug, publicApiKey: newKey },
+      update: {},
+    });
 }
 
 export interface ChatSource {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { Webhook } from 'svix';
 import { prisma, OrganizationRole } from '@app/database';
 import { getEnv } from '@app/shared';
+import crypto from 'crypto';
 
 export const webhooksRouter: Router = Router();
 
@@ -105,10 +106,11 @@ interface ClerkUserData {
       case 'organization.updated': {
         const name = data.name as string;
         const slug = (data.slug as string) || (data.id as string);
+        const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
 
         await prisma.organization.upsert({
           where: { slug },
-          create: { name, slug },
+          create: { name, slug, publicApiKey: newKey },
           update: { name },
         });
         break;
@@ -135,9 +137,10 @@ interface ClerkUserData {
           return;
         }
 
+        const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
         const org = await prisma.organization.upsert({
           where: { slug: orgSlug },
-          create: { name: orgName, slug: orgSlug },
+          create: { name: orgName, slug: orgSlug, publicApiKey: newKey },
           update: { name: orgName },
         });
 


### PR DESCRIPTION
Ensures that a public API key is automatically generated and attached when an organization is first created via webhooks or chat initialization, fulfilling the acceptance criteria for Issue #19.