### PR TITLE
feat: send resend email notification to agents on new ticket (Issue #22)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "openai": "^7.2.0",
     "pino": "^9.5.0",
     "pino-http": "^10.3.0",
+    "resend": "^6.18.1",
     "svix": "^1.99.1"
   },
   "devDependencies": {

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -266,6 +266,42 @@ chatRouter.post(
         where: { id: conversation.id },
         data: { status: 'PENDING_HUMAN' },
       });
+
+      // ponytail: fire-and-forget email to admins/owners — no separate job
+      const env = getEnv();
+      if (env.RESEND_API_KEY) {
+        const { Resend } = await import('resend');
+        const resend = new Resend(env.RESEND_API_KEY);
+
+        const admins = await prisma.membership.findMany({
+          where: {
+            organizationId: org.id,
+            role: { in: ['OWNER', 'ADMIN'] },
+          },
+          include: { user: true },
+        });
+
+        const firstMsg = await prisma.message.findFirst({
+          where: { conversationId: conversation.id, sender: 'CUSTOMER' },
+          orderBy: { createdAt: 'asc' },
+        });
+
+        const ticketUrl = `${env.NEXT_PUBLIC_API_URL?.replace(':4000', ':3000') ?? 'http://localhost:3000'}/dashboard/conversations?id=${conversation.id}`;
+        const customerInfo = conversation.customerEmail ?? 'Anonymous visitor';
+
+        for (const m of admins) {
+          resend.emails.send({
+            from: 'AI Support <onboarding@resend.dev>',
+            to: m.user.email,
+            subject: `New ticket: customer needs human help`,
+            html: `<h2>New Support Ticket</h2>
+              <p><strong>Customer:</strong> ${customerInfo}</p>
+              <p><strong>First message:</strong></p>
+              <blockquote>${firstMsg?.content ?? '(no message)'}</blockquote>
+              <p><a href="${ticketUrl}">View ticket in dashboard →</a></p>`,
+          }).catch((err: unknown) => console.error('Resend email failed:', err));
+        }
+      }
     }
 
     res.status(201).json({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       pino-http:
         specifier: ^10.3.0
         version: 10.5.0
+      resend:
+        specifier: ^6.18.1
+        version: 6.18.1
       svix:
         specifier: ^1.99.1
         version: 1.99.1
@@ -2309,6 +2312,9 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -2452,6 +2458,15 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resend@6.18.1:
+    resolution: {integrity: sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4814,6 +4829,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  postal-mime@2.7.5: {}
+
   postcss-import@15.1.0(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
@@ -4945,6 +4962,11 @@ snapshots:
       redis-errors: 1.2.0
 
   require-from-string@2.0.2: {}
+
+  resend@6.18.1:
+    dependencies:
+      postal-mime: 2.7.5
+      standardwebhooks: 1.0.0
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
## Overview
This PR completes Issue #22 by implementing an automatic Resend email notification when a conversation enters the `PENDING_HUMAN` state.

## Changes Made
- **API Chat Route (`apps/api/src/routes/chat.ts`)**:
  - Imported and initialized `Resend` (only if `RESEND_API_KEY` is present).
  - Queried all `ADMIN` and `OWNER` memberships of the current organization.
  - Fetched the customer's first message from the database.
  - Added a fire-and-forget inline handler to send an HTML email to each admin containing the customer details, first message, and a direct link to the dashboard ticket.
- **Dependencies (`apps/api/package.json`)**: 
  - Added `resend` package to the API workspace.

## Testing Performed
- [x] Verified email is sent within seconds of the status change.
- [x] Verified email includes customer name/email, first customer message, and link to the ticket in the dashboard.
- [x] Verified `RESEND_API_KEY` check works safely if missing.

Closes #22
