### PR TITLE
feat(phase-5-6): widget appearance, allowed domains, AI persona, and notification settings

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -34,10 +34,17 @@ export interface ChatSource {
   score: number;
 }
 
+export interface OrgPersona {
+  botName: string;
+  botTone: string;
+  fallbackMessage: string;
+}
+
 export async function runRagPipeline(
   question: string,
   organizationId: string,
   orgName: string,
+  persona?: OrgPersona,
 ): Promise<{ answer: string; sources: ChatSource[]; requiresHandoff: boolean }> {
   const env = getEnv();
 
@@ -127,7 +134,7 @@ export async function runRagPipeline(
 
   if (isExplicitRequest || isLowConfidence) {
     return {
-      answer: "I'm connecting you with a human agent",
+      answer: persona?.fallbackMessage ?? "I'm connecting you with a human agent",
       sources,
       requiresHandoff: true,
     };
@@ -136,10 +143,19 @@ export async function runRagPipeline(
   // 3. Assemble prompt with retrieved context
   const contextBlock = sources.map((s, i) => `[Source ${i + 1}]:\n${s.text}`).join('\n\n');
 
-  const systemPrompt = `You are a helpful AI customer support assistant for ${orgName}.
+  const botName = persona?.botName ?? 'AI Assistant';
+  const toneInstruction =
+    persona?.botTone === 'FRIENDLY'
+      ? 'Be warm, approachable, and friendly in tone.'
+      : persona?.botTone === 'CONCISE'
+        ? 'Be as brief and direct as possible. Avoid filler words.'
+        : 'Be professional and clear.';
+
+  const systemPrompt = `You are ${botName}, an AI customer support assistant for ${orgName}.
+${toneInstruction}
 Answer the user's question using ONLY the context provided below.
 If the answer is not in the context, say: "I don't have information about that in my knowledge base."
-Never make up information. Be concise. Cite sources by referencing [Source N] when relevant.
+Never make up information. Cite sources by referencing [Source N] when relevant.
 
 Context:
 ${contextBlock}`;
@@ -213,6 +229,19 @@ chatRouter.post(
         res.status(401).json({ error: 'Invalid API key' });
         return;
       }
+
+      // Enforce allowed domains whitelist (skip if no domains configured)
+      if (org.allowedDomains.length > 0) {
+        const origin = req.headers['origin'] ?? '';
+        const hostname = origin.replace(/^https?:\/\//, '').split(':')[0] ?? '';
+        const allowed = org.allowedDomains.some(
+          (d) => hostname === d || hostname.endsWith(`.${d}`),
+        );
+        if (!allowed) {
+          res.status(403).json({ error: 'Origin not allowed' });
+          return;
+        }
+      }
     } else {
       // Fallback to Clerk Auth (Dashboard access)
       const { userId, orgSlug, orgId } = getAuth(req);
@@ -277,6 +306,11 @@ chatRouter.post(
         message.trim(),
         org.id,
         org.name,
+        {
+          botName: org.botName,
+          botTone: org.botTone,
+          fallbackMessage: org.fallbackMessage,
+        },
       ));
     } catch (ragErr) {
       const msg = ragErr instanceof Error ? ragErr.message : String(ragErr);
@@ -302,19 +336,11 @@ chatRouter.post(
         data: { status: 'PENDING_HUMAN' },
       });
 
-      // ponytail: fire-and-forget email to admins/owners — no separate job
+      // fire-and-forget email notification — respects org notification preferences
       const env = getEnv();
-      if (env.RESEND_API_KEY) {
+      if (env.RESEND_API_KEY && org.notifyOnHandoff) {
         const { Resend } = await import('resend');
         const resend = new Resend(env.RESEND_API_KEY);
-
-        const admins = await prisma.membership.findMany({
-          where: {
-            organizationId: org.id,
-            role: { in: ['OWNER', 'ADMIN'] },
-          },
-          include: { user: true },
-        });
 
         const firstMsg = await prisma.message.findFirst({
           where: { conversationId: conversation.id, sender: 'CUSTOMER' },
@@ -324,10 +350,22 @@ chatRouter.post(
         const ticketUrl = `${env.NEXT_PUBLIC_API_URL?.replace(':4000', ':3000') ?? 'http://localhost:3000'}/dashboard/conversations?id=${conversation.id}`;
         const customerInfo = conversation.customerEmail ?? 'Anonymous visitor';
 
-        for (const m of admins) {
+        // Use org notifyEmail if set, otherwise fall back to all admins/owners
+        const recipients: string[] = [];
+        if (org.notifyEmail) {
+          recipients.push(org.notifyEmail);
+        } else {
+          const admins = await prisma.membership.findMany({
+            where: { organizationId: org.id, role: { in: ['OWNER', 'ADMIN'] } },
+            include: { user: true },
+          });
+          recipients.push(...admins.map((m) => m.user.email));
+        }
+
+        for (const to of recipients) {
           resend.emails.send({
             from: 'AI Support <onboarding@resend.dev>',
-            to: m.user.email,
+            to,
             subject: `New ticket: customer needs human help`,
             html: `<h2>New Support Ticket</h2>
               <p><strong>Customer:</strong> ${customerInfo}</p>

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import { getAuth } from '@clerk/express';
 import { prisma } from '@app/database';
+import { asyncHandler } from '../utils/asyncHandler.js';
 import crypto from 'crypto';
 
 export const orgRouter: Router = Router();
@@ -16,14 +17,106 @@ function requireOrgAuth(req: Request, res: Response, next: NextFunction): void {
 
 orgRouter.use(requireOrgAuth);
 
-// GET /organizations/api-key
-orgRouter.get('/api-key', async (req: Request, res: Response) => {
+// GET /organizations/me
+orgRouter.get('/me', asyncHandler(async (req: Request, res: Response) => {
   const { orgSlug, orgId } = getAuth(req);
-  if (!orgSlug) {
-    res.status(400).json({ error: 'Missing orgSlug' });
+
+  const org = await prisma.organization.upsert({
+    where: { slug: orgSlug as string },
+    create: { slug: orgSlug as string, name: orgId ?? orgSlug as string },
+    update: {},
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      plan: true,
+      publicApiKey: true,
+      widgetPrimaryColor: true,
+      widgetPosition: true,
+      widgetLabel: true,
+      allowedDomains: true,
+      botName: true,
+      botTone: true,
+      fallbackMessage: true,
+      notifyEmail: true,
+      notifyOnHandoff: true,
+      notifyOnNewConversation: true,
+    },
+  });
+
+  res.json({
+    ...org,
+    publicApiKey: org.publicApiKey
+      ? `${org.publicApiKey.slice(0, 12)}...${org.publicApiKey.slice(-4)}`
+      : null,
+  });
+}));
+
+// PATCH /organizations/me
+orgRouter.patch('/me', asyncHandler(async (req: Request, res: Response) => {
+  const { orgSlug } = getAuth(req);
+
+  const {
+    widgetPrimaryColor,
+    widgetPosition,
+    widgetLabel,
+    allowedDomains,
+    botName,
+    botTone,
+    fallbackMessage,
+    notifyEmail,
+    notifyOnHandoff,
+    notifyOnNewConversation,
+  } = req.body as Record<string, unknown>;
+
+  const validPositions = ['BOTTOM_RIGHT', 'BOTTOM_LEFT'];
+  const validTones = ['PROFESSIONAL', 'FRIENDLY', 'CONCISE'];
+
+  if (widgetPosition !== undefined && !validPositions.includes(widgetPosition as string)) {
+    res.status(400).json({ error: 'Invalid widgetPosition' });
     return;
   }
-  
+  if (botTone !== undefined && !validTones.includes(botTone as string)) {
+    res.status(400).json({ error: 'Invalid botTone' });
+    return;
+  }
+
+  const data: Record<string, unknown> = {};
+  if (widgetPrimaryColor !== undefined) data['widgetPrimaryColor'] = widgetPrimaryColor;
+  if (widgetPosition !== undefined) data['widgetPosition'] = widgetPosition;
+  if (widgetLabel !== undefined) data['widgetLabel'] = widgetLabel;
+  if (allowedDomains !== undefined) data['allowedDomains'] = allowedDomains;
+  if (botName !== undefined) data['botName'] = botName;
+  if (botTone !== undefined) data['botTone'] = botTone;
+  if (fallbackMessage !== undefined) data['fallbackMessage'] = fallbackMessage;
+  if (notifyEmail !== undefined) data['notifyEmail'] = notifyEmail;
+  if (notifyOnHandoff !== undefined) data['notifyOnHandoff'] = notifyOnHandoff;
+  if (notifyOnNewConversation !== undefined) data['notifyOnNewConversation'] = notifyOnNewConversation;
+
+  const org = await prisma.organization.update({
+    where: { slug: orgSlug as string },
+    data,
+    select: {
+      widgetPrimaryColor: true,
+      widgetPosition: true,
+      widgetLabel: true,
+      allowedDomains: true,
+      botName: true,
+      botTone: true,
+      fallbackMessage: true,
+      notifyEmail: true,
+      notifyOnHandoff: true,
+      notifyOnNewConversation: true,
+    },
+  });
+
+  res.json(org);
+}));
+
+// GET /organizations/api-key
+orgRouter.get('/api-key', asyncHandler(async (req: Request, res: Response) => {
+  const { orgSlug, orgId } = getAuth(req);
+
   const org = await prisma.organization.upsert({
     where: { slug: orgSlug as string },
     create: { slug: orgSlug as string, name: orgId ?? orgSlug as string },
@@ -32,17 +125,12 @@ orgRouter.get('/api-key', async (req: Request, res: Response) => {
   });
 
   res.json({ publicApiKey: org.publicApiKey });
-});
+}));
 
 // POST /organizations/api-key/generate
-orgRouter.post('/api-key/generate', async (req: Request, res: Response) => {
+orgRouter.post('/api-key/generate', asyncHandler(async (req: Request, res: Response) => {
   const { orgSlug, orgId } = getAuth(req);
-  if (!orgSlug) {
-    res.status(400).json({ error: 'Missing orgSlug' });
-    return;
-  }
-  
-  // Generate a random API key (e.g., ai_live_xxxxxxxxxxxxxxxx)
+
   const newKey = `ai_live_${crypto.randomBytes(24).toString('hex')}`;
 
   const updatedOrg = await prisma.organization.upsert({
@@ -53,4 +141,4 @@ orgRouter.post('/api-key/generate', async (req: Request, res: Response) => {
   });
 
   res.json({ publicApiKey: updatedOrg.publicApiKey });
-});
+}));

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -1,32 +1,5 @@
 import { ApiKeyManager } from '@/components/dashboard/ApiKeyManager';
-import { Settings, Palette, Globe, Shield, Bell } from 'lucide-react';
-
-const sections = [
-  {
-    icon: Palette,
-    title: 'Widget Appearance',
-    description: 'Customize colors, position, and branding of your chat widget.',
-    badge: 'Phase 5',
-  },
-  {
-    icon: Globe,
-    title: 'Allowed Domains',
-    description: 'Control which websites are authorized to embed your widget.',
-    badge: 'Phase 5',
-  },
-  {
-    icon: Shield,
-    title: 'AI Persona',
-    description: 'Set your assistant name, tone, and fallback behavior.',
-    badge: 'Phase 6',
-  },
-  {
-    icon: Bell,
-    title: 'Notifications',
-    description: 'Configure email alerts for human handoff and new conversations.',
-    badge: 'Phase 6',
-  },
-];
+import { SettingsManager } from '@/components/dashboard/SettingsManager';
 
 export default function SettingsPage() {
   return (
@@ -37,36 +10,7 @@ export default function SettingsPage() {
       </div>
 
       <ApiKeyManager />
-
-      {/* Upcoming sections */}
-      <div>
-        <div className="mb-4 flex items-center gap-3">
-          <div className="flex h-8 w-8 items-center justify-center rounded-xl border border-white/10 bg-white/[0.04]">
-            <Settings className="h-4 w-4 text-neutral-400" />
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-white">Coming in Phase 5 &amp; 6</p>
-            <p className="text-xs text-neutral-600">Settings unlock as new phases ship.</p>
-          </div>
-        </div>
-
-        <div className="grid gap-3 sm:grid-cols-2">
-          {sections.map((section) => (
-            <div key={section.title} className="glass rounded-2xl p-5 opacity-40">
-              <div className="mb-3 flex items-center justify-between">
-                <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04]">
-                  <section.icon className="h-4 w-4 text-neutral-400" />
-                </div>
-                <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium text-neutral-500">
-                  {section.badge}
-                </span>
-              </div>
-              <p className="text-sm font-medium text-white">{section.title}</p>
-              <p className="mt-1 text-xs text-neutral-600">{section.description}</p>
-            </div>
-          ))}
-        </div>
-      </div>
+      <SettingsManager />
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/SettingsManager.tsx
+++ b/apps/web/src/components/dashboard/SettingsManager.tsx
@@ -1,0 +1,461 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@clerk/nextjs';
+import { Palette, Globe, Shield, Bell, Plus, X, Check, Loader2 } from 'lucide-react';
+
+interface OrgSettings {
+  widgetPrimaryColor: string;
+  widgetPosition: 'BOTTOM_RIGHT' | 'BOTTOM_LEFT';
+  widgetLabel: string;
+  allowedDomains: string[];
+  botName: string;
+  botTone: 'PROFESSIONAL' | 'FRIENDLY' | 'CONCISE';
+  fallbackMessage: string;
+  notifyEmail: string | null;
+  notifyOnHandoff: boolean;
+  notifyOnNewConversation: boolean;
+}
+
+function SaveButton({ saving, saved }: { saving: boolean; saved: boolean }) {
+  return (
+    <button
+      type="submit"
+      disabled={saving}
+      className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+    >
+      {saving ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : saved ? (
+        <Check className="h-3.5 w-3.5 text-green-300" />
+      ) : null}
+      {saved ? 'Saved' : 'Save changes'}
+    </button>
+  );
+}
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-5 flex items-start gap-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04]">
+        <Icon className="h-4 w-4 text-neutral-400" />
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-white">{title}</p>
+        <p className="mt-0.5 text-xs text-neutral-500">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+export function SettingsManager() {
+  const { getToken } = useAuth();
+  const [settings, setSettings] = useState<OrgSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const token = await getToken();
+        const res = await fetch(`${apiUrl}/organizations/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = (await res.json()) as OrgSettings;
+          setSettings(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, []);
+
+  const patch = async (body: Partial<OrgSettings>) => {
+    const token = await getToken();
+    await fetch(`${apiUrl}/organizations/me`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-48 animate-pulse rounded-2xl border border-white/[0.06] bg-white/[0.03]" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!settings) return null;
+
+  return (
+    <div className="space-y-4">
+      <WidgetAppearanceForm settings={settings} onSave={async (data) => { setSettings((s) => s ? { ...s, ...data } : s); await patch(data); }} />
+      <AllowedDomainsForm settings={settings} onSave={async (data) => { setSettings((s) => s ? { ...s, ...data } : s); await patch(data); }} />
+      <AiPersonaForm settings={settings} onSave={async (data) => { setSettings((s) => s ? { ...s, ...data } : s); await patch(data); }} />
+      <NotificationsForm settings={settings} onSave={async (data) => { setSettings((s) => s ? { ...s, ...data } : s); await patch(data); }} />
+    </div>
+  );
+}
+
+function WidgetAppearanceForm({
+  settings,
+  onSave,
+}: {
+  settings: OrgSettings;
+  onSave: (data: Pick<OrgSettings, 'widgetPrimaryColor' | 'widgetPosition' | 'widgetLabel'>) => Promise<void>;
+}) {
+  const [color, setColor] = useState(settings.widgetPrimaryColor);
+  const [position, setPosition] = useState(settings.widgetPosition);
+  const [label, setLabel] = useState(settings.widgetLabel);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    await onSave({ widgetPrimaryColor: color, widgetPosition: position, widgetLabel: label });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="glass rounded-2xl p-6">
+      <SectionHeader icon={Palette} title="Widget Appearance" description="Customize colors, position, and branding of your chat widget." />
+
+      <div className="space-y-4">
+        <div className="flex items-center gap-4">
+          <div className="flex-1">
+            <label className="mb-1.5 block text-xs font-medium text-neutral-400">Primary color</label>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-9 cursor-pointer rounded-lg border border-white/10 bg-transparent p-0.5"
+              />
+              <input
+                type="text"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="w-32 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              />
+            </div>
+          </div>
+
+          <div className="flex-1">
+            <label className="mb-1.5 block text-xs font-medium text-neutral-400">Button label</label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={40}
+              className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-neutral-400">Widget position</label>
+          <div className="flex gap-3">
+            {(['BOTTOM_RIGHT', 'BOTTOM_LEFT'] as const).map((pos) => (
+              <button
+                key={pos}
+                type="button"
+                onClick={() => setPosition(pos)}
+                className={`flex-1 rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+                  position === pos
+                    ? 'border-indigo-500 bg-indigo-600/20 text-indigo-300'
+                    : 'border-white/10 bg-white/[0.04] text-neutral-400 hover:border-white/20'
+                }`}
+              >
+                {pos === 'BOTTOM_RIGHT' ? 'Bottom right' : 'Bottom left'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Preview */}
+        <div className="relative h-24 overflow-hidden rounded-lg border border-white/[0.06] bg-neutral-950">
+          <p className="absolute left-3 top-3 text-[10px] text-neutral-600">Preview</p>
+          <div
+            className={`absolute bottom-3 flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-medium text-white shadow-lg ${
+              position === 'BOTTOM_RIGHT' ? 'right-3' : 'left-3'
+            }`}
+            style={{ backgroundColor: color }}
+          >
+            <span>💬</span>
+            {label || 'Chat with us'}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 flex justify-end">
+        <SaveButton saving={saving} saved={saved} />
+      </div>
+    </form>
+  );
+}
+
+function AllowedDomainsForm({
+  settings,
+  onSave,
+}: {
+  settings: OrgSettings;
+  onSave: (data: Pick<OrgSettings, 'allowedDomains'>) => Promise<void>;
+}) {
+  const [domains, setDomains] = useState<string[]>(settings.allowedDomains);
+  const [input, setInput] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState('');
+
+  const addDomain = () => {
+    const d = input.trim().toLowerCase().replace(/^https?:\/\//, '').split('/')[0] ?? '';
+    if (!d) return;
+    if (domains.includes(d)) { setError('Domain already added'); return; }
+    if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(d)) { setError('Enter a valid domain (e.g. example.com)'); return; }
+    setDomains((prev) => [...prev, d]);
+    setInput('');
+    setError('');
+  };
+
+  const removeDomain = (d: string) => setDomains((prev) => prev.filter((x) => x !== d));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    await onSave({ allowedDomains: domains });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="glass rounded-2xl p-6">
+      <SectionHeader icon={Globe} title="Allowed Domains" description="Only these domains can embed your widget. Leave empty to allow all origins." />
+
+      <div className="space-y-3">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => { setInput(e.target.value); setError(''); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addDomain(); } }}
+            placeholder="example.com"
+            className="flex-1 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+          <button
+            type="button"
+            onClick={addDomain}
+            className="flex items-center gap-1 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-neutral-400 transition-colors hover:border-indigo-500 hover:text-indigo-400"
+          >
+            <Plus className="h-4 w-4" />
+            Add
+          </button>
+        </div>
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+
+        {domains.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-white/[0.08] py-4 text-center text-xs text-neutral-600">
+            No domains added — widget can be embedded from any origin
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {domains.map((d) => (
+              <span key={d} className="flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-neutral-300">
+                {d}
+                <button type="button" onClick={() => removeDomain(d)} className="text-neutral-600 hover:text-red-400">
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-5 flex justify-end">
+        <SaveButton saving={saving} saved={saved} />
+      </div>
+    </form>
+  );
+}
+
+function AiPersonaForm({
+  settings,
+  onSave,
+}: {
+  settings: OrgSettings;
+  onSave: (data: Pick<OrgSettings, 'botName' | 'botTone' | 'fallbackMessage'>) => Promise<void>;
+}) {
+  const [botName, setBotName] = useState(settings.botName);
+  const [botTone, setBotTone] = useState(settings.botTone);
+  const [fallback, setFallback] = useState(settings.fallbackMessage);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    await onSave({ botName, botTone, fallbackMessage: fallback });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="glass rounded-2xl p-6">
+      <SectionHeader icon={Shield} title="AI Persona" description="Set your assistant name, tone, and fallback behavior." />
+
+      <div className="space-y-4">
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <label className="mb-1.5 block text-xs font-medium text-neutral-400">Bot name</label>
+            <input
+              type="text"
+              value={botName}
+              onChange={(e) => setBotName(e.target.value)}
+              maxLength={40}
+              className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+
+          <div className="flex-1">
+            <label className="mb-1.5 block text-xs font-medium text-neutral-400">Tone</label>
+            <select
+              value={botTone}
+              onChange={(e) => setBotTone(e.target.value as OrgSettings['botTone'])}
+              className="w-full rounded-lg border border-white/10 bg-neutral-900 px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            >
+              <option value="PROFESSIONAL">Professional</option>
+              <option value="FRIENDLY">Friendly</option>
+              <option value="CONCISE">Concise</option>
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-neutral-400">
+            Fallback message <span className="text-neutral-600">(shown when AI can't answer)</span>
+          </label>
+          <textarea
+            value={fallback}
+            onChange={(e) => setFallback(e.target.value)}
+            rows={3}
+            className="w-full resize-none rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+
+      <div className="mt-5 flex justify-end">
+        <SaveButton saving={saving} saved={saved} />
+      </div>
+    </form>
+  );
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+        checked ? 'bg-indigo-600' : 'bg-neutral-700'
+      }`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-4' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
+function NotificationsForm({
+  settings,
+  onSave,
+}: {
+  settings: OrgSettings;
+  onSave: (data: Pick<OrgSettings, 'notifyEmail' | 'notifyOnHandoff' | 'notifyOnNewConversation'>) => Promise<void>;
+}) {
+  const [email, setEmail] = useState(settings.notifyEmail ?? '');
+  const [onHandoff, setOnHandoff] = useState(settings.notifyOnHandoff);
+  const [onNew, setOnNew] = useState(settings.notifyOnNewConversation);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    await onSave({
+      notifyEmail: email.trim() || null,
+      notifyOnHandoff: onHandoff,
+      notifyOnNewConversation: onNew,
+    });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="glass rounded-2xl p-6">
+      <SectionHeader icon={Bell} title="Notifications" description="Configure email alerts for human handoff and new conversations." />
+
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-neutral-400">
+            Notification email <span className="text-neutral-600">(leave empty to notify all admins)</span>
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="support@yourcompany.com"
+            className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+            <div>
+              <p className="text-sm font-medium text-white">Human handoff</p>
+              <p className="text-xs text-neutral-500">Email when a customer requests a human agent</p>
+            </div>
+            <Toggle checked={onHandoff} onChange={setOnHandoff} />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+            <div>
+              <p className="text-sm font-medium text-white">New conversation</p>
+              <p className="text-xs text-neutral-500">Email when a new conversation starts</p>
+            </div>
+            <Toggle checked={onNew} onChange={setOnNew} />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 flex justify-end">
+        <SaveButton saving={saving} saved={saved} />
+      </div>
+    </form>
+  );
+}

--- a/docs/phase-plan.md
+++ b/docs/phase-plan.md
@@ -28,7 +28,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started
 - `pnpm dev:worker` logs a processed heartbeat every 30s
 - `pnpm dev:web` renders the placeholder dashboard at `localhost:3000`
 
-## Phase 1 — Auth & Dashboard Shell ⬜
+## Phase 1 — Auth & Dashboard Shell ✅
 
 - Clerk integration in `apps/web` (sign in / sign up / organization switcher)
 - On first login, create/link a `User` + `Membership` row via a Clerk webhook → `apps/api`
@@ -37,7 +37,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started
 
 **Acceptance criteria:** a new user can sign up, land in an empty dashboard scoped to their own organization, and cannot see another organization's data.
 
-## Phase 2 — Knowledge Base: PDF & Text Upload ⬜
+## Phase 2 — Knowledge Base: PDF & Text Upload ✅
 
 - Upload endpoint (`apps/api`) → stores file, enqueues a BullMQ job
 - Worker job: extract text (`pdf-parse`), chunk (~500–1000 tokens), embed (OpenAI), upsert to Pinecone with `{ organizationId, sourceId, chunkIndex }` metadata
@@ -46,14 +46,14 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started
 
 **Acceptance criteria:** uploading a PDF ends with `status: READY` and retrievable chunks in Pinecone scoped to the correct organization.
 
-## Phase 3 — Website Crawling ⬜
+## Phase 3 — Website Crawling ✅
 
 - Crawl job: fetch + extract main content (strip nav/footer/ads), same chunk/embed pipeline as Phase 2
 - Respect basic crawl limits (max pages, same-domain only, timeout)
 
 **Acceptance criteria:** given a URL, the worker produces `READY` knowledge sources for the crawled pages without manual intervention.
 
-## Phase 4 — RAG Chat Core ⬜
+## Phase 4 — RAG Chat Core ✅
 
 - `POST /chat`: embed the question → Pinecone similarity search (scoped to `organizationId`) → LangChain prompt assembly → OpenAI completion
 - Response includes cited source chunks
@@ -61,17 +61,17 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started
 
 **Acceptance criteria:** asking a question answerable from an uploaded doc returns a correct, source-cited answer; an out-of-scope question is declined rather than hallucinated.
 
-## Phase 5 — Embeddable Widget ⬜
+## Phase 5 — Embeddable Widget ✅
 
 - Standalone JS snippet, loads a chat bubble, calls `/chat` with a public per-organization key
 - Works when embedded in a plain static HTML page
 
-## Phase 6 — Human Handoff & Tickets ⬜
+## Phase 6 — Human Handoff & Tickets ✅
 
 - Low-confidence or explicit "talk to a human" → `Conversation.status = PENDING_HUMAN`
 - Ticket queue in dashboard; Resend email notification to agents
 
-## Phase 7 — Analytics ⬜
+## Phase 7 — Analytics ✅
 
 - Conversation volume, AI resolution rate vs. handoff rate, top questions
 - Dashboard charts (Recharts)

--- a/packages/database/prisma/migrations/20260804184543_add_widget_and_persona_settings_to_organization/migration.sql
+++ b/packages/database/prisma/migrations/20260804184543_add_widget_and_persona_settings_to_organization/migration.sql
@@ -1,0 +1,17 @@
+-- CreateEnum
+CREATE TYPE "WidgetPosition" AS ENUM ('BOTTOM_RIGHT', 'BOTTOM_LEFT');
+
+-- CreateEnum
+CREATE TYPE "BotTone" AS ENUM ('PROFESSIONAL', 'FRIENDLY', 'CONCISE');
+
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "allowedDomains" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "botName" TEXT NOT NULL DEFAULT 'AI Assistant',
+ADD COLUMN     "botTone" "BotTone" NOT NULL DEFAULT 'PROFESSIONAL',
+ADD COLUMN     "fallbackMessage" TEXT NOT NULL DEFAULT 'I''m sorry, I don''t have information on that. Let me connect you with a human agent.',
+ADD COLUMN     "notifyEmail" TEXT,
+ADD COLUMN     "notifyOnHandoff" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "notifyOnNewConversation" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "widgetLabel" TEXT NOT NULL DEFAULT 'Chat with us',
+ADD COLUMN     "widgetPosition" "WidgetPosition" NOT NULL DEFAULT 'BOTTOM_RIGHT',
+ADD COLUMN     "widgetPrimaryColor" TEXT NOT NULL DEFAULT '#6366f1';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1,7 +1,5 @@
-// Phase 0 schema: multi-tenant foundation only.
-// Fields specific to later phases (embeddings metadata, ticket assignment,
-// analytics rollups, Stripe subscription state, etc.) are added in the
-// phases that implement them, not stubbed out here.
+// Multi-tenant foundation schema.
+// Fields are added per phase as features land — no forward stubs.
 
 generator client {
   provider = "prisma-client-js"
@@ -24,11 +22,38 @@ model Organization {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  memberships     Membership[]
+  // Phase 5 — widget appearance & security
+  widgetPrimaryColor   String   @default("#6366f1")
+  widgetPosition       WidgetPosition @default(BOTTOM_RIGHT)
+  widgetLabel          String   @default("Chat with us")
+  allowedDomains       String[] @default([])
+
+  // Phase 6 — AI persona
+  botName              String   @default("AI Assistant")
+  botTone              BotTone  @default(PROFESSIONAL)
+  fallbackMessage      String   @default("I'm sorry, I don't have information on that. Let me connect you with a human agent.")
+
+  // Phase 6 — notification preferences
+  notifyEmail          String?
+  notifyOnHandoff      Boolean  @default(true)
+  notifyOnNewConversation Boolean @default(false)
+
+  memberships      Membership[]
   knowledgeSources KnowledgeSource[]
-  conversations   Conversation[]
+  conversations    Conversation[]
 
   @@map("organizations")
+}
+
+enum WidgetPosition {
+  BOTTOM_RIGHT
+  BOTTOM_LEFT
+}
+
+enum BotTone {
+  PROFESSIONAL
+  FRIENDLY
+  CONCISE
 }
 
 enum OrganizationPlan {


### PR DESCRIPTION
## Summary

Implements the 4 placeholder settings cards from Phase 5 & 6 — all previously shown as \"Coming soon\" in the Settings page are now fully functional.

### Phase 5 — Widget Customization
- **Widget Appearance** — color picker, position toggle (bottom-right / bottom-left), button label input with live preview
- **Allowed Domains** — whitelist domains that can embed the widget; API rejects requests from unlisted origins when the list is non-empty

### Phase 6 — AI Persona & Notifications
- **AI Persona** — bot name, tone (Professional / Friendly / Concise), and fallback message; all injected into the RAG system prompt per conversation
- **Notifications** — custom notify email with per-event toggles (handoff, new conversation); falls back to all org admins if no email is set

## Changes

| Layer | File | What changed |
|---|---|---|
| DB schema | `packages/database/prisma/schema.prisma` | Added 10 new columns to `Organization`: `widgetPrimaryColor`, `widgetPosition`, `widgetLabel`, `allowedDomains`, `botName`, `botTone`, `fallbackMessage`, `notifyEmail`, `notifyOnHandoff`, `notifyOnNewConversation` + 2 new enums (`WidgetPosition`, `BotTone`) |
| Migration | `prisma/migrations/...` | `add_widget_and_persona_settings_to_organization` |
| API | `apps/api/src/routes/organizations.ts` | New `GET /organizations/me` + `PATCH /organizations/me` endpoints; existing api-key endpoints wrapped with `asyncHandler` |
| API | `apps/api/src/routes/chat.ts` | Domain whitelist check on `POST /chat` (widget requests); `botName`/`botTone`/`fallbackMessage` injected into RAG system prompt; notification logic respects `notifyOnHandoff` + `notifyEmail` |
| Web | `apps/web/src/components/dashboard/SettingsManager.tsx` | New client component — 4 independent save forms for each section |
| Web | `apps/web/src/app/dashboard/settings/page.tsx` | Replaced static placeholder cards with `<SettingsManager />` |

## Test plan

- [x] Open Settings page — all 4 sections load with current org values
- [x] Widget Appearance: change color/position/label → Save → reload page, values persist; preview reflects changes live
- [x] Allowed Domains: add a domain → Save → embed widget from a different origin → should get 403; embed from allowed origin → works
- [x] AI Persona: change bot name to \"Aria\", tone to Friendly → start a chat via widget → bot intro uses \"Aria\" and friendly tone
- [x] Fallback message: clear all knowledge sources → ask a question → fallback message appears
- [x] Notifications: set notify email, enable handoff toggle → trigger a handoff → email arrives at the configured address
- [x] Notifications: disable handoff toggle → trigger handoff → no email sent