### PR TITLE
feat(phase-8): Stripe billing with plan limits and subscription management

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "pino": "^9.5.0",
     "pino-http": "^10.3.0",
     "resend": "^6.18.1",
+    "stripe": "^22.4.0",
     "svix": "^1.99.1"
   },
   "devDependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import { knowledgeSourcesRouter } from './routes/knowledge-sources.js';
 import { chatRouter, conversationsRouter } from './routes/chat.js';
 import { orgRouter } from './routes/organizations.js';
 import { analyticsRouter } from './routes/analytics.js';
+import { billingRouter } from './routes/billing.js';
 
 export function createApp(): Express {
   const app = express();
@@ -38,6 +39,7 @@ export function createApp(): Express {
   app.use('/conversations', conversationsRouter);
   app.use('/organizations', orgRouter);
   app.use('/analytics', analyticsRouter);
+  app.use('/billing', billingRouter);
 
   // Global error handler — catches any error thrown/rejected inside route handlers
   // Prevents unhandled rejections from crashing the process

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -1,0 +1,150 @@
+import { Router, type Request, type Response } from 'express';
+import { getAuth } from '@clerk/express';
+import Stripe from 'stripe';
+import { prisma } from '@app/database';
+import { getEnv } from '@app/shared';
+import { asyncHandler } from '../utils/asyncHandler.js';
+
+export const billingRouter: Router = Router();
+
+export const PLAN_LIMITS = {
+  FREE: { knowledgeSources: 3, conversationsPerMonth: 100 },
+  PRO: { knowledgeSources: 20, conversationsPerMonth: 1000 },
+  ENTERPRISE: { knowledgeSources: Infinity, conversationsPerMonth: Infinity },
+};
+
+function getStripe(): Stripe {
+  const env = getEnv();
+  if (!env.STRIPE_SECRET_KEY) throw new Error('STRIPE_SECRET_KEY is not configured');
+  return new Stripe(env.STRIPE_SECRET_KEY);
+}
+
+function requireOrgAuth(req: Request, res: Response, next: () => void): void {
+  const { userId, orgSlug } = getAuth(req);
+  if (!userId || !orgSlug) {
+    res.status(401).json({ error: 'Unauthorized or no active organization' });
+    return;
+  }
+  next();
+}
+
+billingRouter.use(requireOrgAuth);
+
+// GET /billing/status — plan, usage, limits
+billingRouter.get('/status', asyncHandler(async (req: Request, res: Response) => {
+  const { orgSlug, orgId } = getAuth(req);
+
+  const org = await prisma.organization.upsert({
+    where: { slug: orgSlug as string },
+    create: { slug: orgSlug as string, name: orgId ?? orgSlug as string },
+    update: {},
+    select: { id: true, plan: true, currentPeriodEnd: true, stripeSubscriptionId: true },
+  });
+
+  const now = new Date();
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  const [sourceCount, convCount] = await Promise.all([
+    prisma.knowledgeSource.count({ where: { organizationId: org.id } }),
+    prisma.conversation.count({
+      where: { organizationId: org.id, createdAt: { gte: startOfMonth } },
+    }),
+  ]);
+
+  const limits = PLAN_LIMITS[org.plan];
+
+  res.json({
+    plan: org.plan,
+    currentPeriodEnd: org.currentPeriodEnd,
+    hasActiveSubscription: !!org.stripeSubscriptionId,
+    usage: {
+      knowledgeSources: { used: sourceCount, limit: limits.knowledgeSources },
+      conversationsThisMonth: { used: convCount, limit: limits.conversationsPerMonth },
+    },
+  });
+}));
+
+// POST /billing/create-checkout — create Stripe Checkout session
+billingRouter.post('/create-checkout', asyncHandler(async (req: Request, res: Response) => {
+  const { orgSlug, orgId } = getAuth(req);
+  const env = getEnv();
+
+  if (!env.STRIPE_SECRET_KEY) {
+    res.status(503).json({ error: 'Stripe is not configured' });
+    return;
+  }
+
+  const { plan } = req.body as { plan?: string };
+  if (!plan || !['PRO', 'ENTERPRISE'].includes(plan)) {
+    res.status(400).json({ error: 'plan must be PRO or ENTERPRISE' });
+    return;
+  }
+
+  const priceId = plan === 'PRO' ? env.STRIPE_PRO_PRICE_ID : env.STRIPE_ENTERPRISE_PRICE_ID;
+  if (!priceId) {
+    res.status(503).json({ error: `STRIPE_${plan}_PRICE_ID is not configured` });
+    return;
+  }
+
+  const org = await prisma.organization.upsert({
+    where: { slug: orgSlug as string },
+    create: { slug: orgSlug as string, name: orgId ?? orgSlug as string },
+    update: {},
+    select: { id: true, stripeCustomerId: true },
+  });
+
+  const stripe = getStripe();
+
+  // Reuse or create Stripe customer
+  let customerId = org.stripeCustomerId ?? undefined;
+  if (!customerId) {
+    const customer = await stripe.customers.create({ metadata: { orgId: org.id, orgSlug: orgSlug as string } });
+    customerId = customer.id;
+    await prisma.organization.update({
+      where: { id: org.id },
+      data: { stripeCustomerId: customerId },
+    });
+  }
+
+  const webUrl = env.NEXT_PUBLIC_WEB_URL;
+  const session = await stripe.checkout.sessions.create({
+    customer: customerId,
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${webUrl}/dashboard/billing?success=1`,
+    cancel_url: `${webUrl}/dashboard/billing?canceled=1`,
+    metadata: { orgId: org.id },
+  });
+
+  res.json({ url: session.url });
+}));
+
+// POST /billing/create-portal — Stripe Customer Portal session
+billingRouter.post('/create-portal', asyncHandler(async (req: Request, res: Response) => {
+  const { orgSlug } = getAuth(req);
+  const env = getEnv();
+
+  if (!env.STRIPE_SECRET_KEY) {
+    res.status(503).json({ error: 'Stripe is not configured' });
+    return;
+  }
+
+  const org = await prisma.organization.findUnique({
+    where: { slug: orgSlug as string },
+    select: { stripeCustomerId: true },
+  });
+
+  if (!org?.stripeCustomerId) {
+    res.status(400).json({ error: 'No Stripe customer found for this organization' });
+    return;
+  }
+
+  const stripe = getStripe();
+  const webUrl = env.NEXT_PUBLIC_WEB_URL;
+  const session = await stripe.billingPortal.sessions.create({
+    customer: org.stripeCustomerId,
+    return_url: `${webUrl}/dashboard/billing`,
+  });
+
+  res.json({ url: session.url });
+}));

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -4,6 +4,7 @@ import OpenAI from 'openai';
 import { Pinecone } from '@pinecone-database/pinecone';
 import { prisma } from '@app/database';
 import { getEnv } from '@app/shared';
+import { PLAN_LIMITS } from './billing.js';
 import crypto from 'crypto';
 
 export const chatRouter: Router = Router();
@@ -273,6 +274,23 @@ chatRouter.post(
         return;
       }
     } else {
+      // Enforce monthly conversation limit
+      const startOfMonth = new Date();
+      startOfMonth.setDate(1);
+      startOfMonth.setHours(0, 0, 0, 0);
+
+      const convCount = await prisma.conversation.count({
+        where: { organizationId: org.id, createdAt: { gte: startOfMonth } },
+      });
+      const limit = PLAN_LIMITS[org.plan].conversationsPerMonth;
+      if (convCount >= limit) {
+        res.status(403).json({
+          error: `Monthly conversation limit reached (${limit} on ${org.plan} plan). Upgrade to continue.`,
+          code: 'LIMIT_EXCEEDED',
+        });
+        return;
+      }
+
       conversation = await prisma.conversation.create({
         data: { organizationId: org.id, status: 'OPEN' },
       });

--- a/apps/api/src/routes/knowledge-sources.ts
+++ b/apps/api/src/routes/knowledge-sources.ts
@@ -7,6 +7,7 @@ import { mkdirSync } from 'fs';
 import { Queue } from 'bullmq';
 import { prisma } from '@app/database';
 import { getRedisConnectionOptions } from '../connection.js';
+import { PLAN_LIMITS } from './billing.js';
 
 interface PdfProcessingJobData {
   knowledgeSourceId: string;
@@ -83,7 +84,18 @@ knowledgeSourcesRouter.post(
       where: { slug: orgSlug },
       create: { slug: orgSlug, name: orgId ?? orgSlug },
       update: {},
+      select: { id: true, plan: true },
     });
+
+    const sourceCount = await prisma.knowledgeSource.count({ where: { organizationId: org.id } });
+    const limit = PLAN_LIMITS[org.plan].knowledgeSources;
+    if (sourceCount >= limit) {
+      res.status(403).json({
+        error: `Knowledge source limit reached (${limit} on ${org.plan} plan). Upgrade to add more.`,
+        code: 'LIMIT_EXCEEDED',
+      });
+      return;
+    }
 
     const source = await prisma.knowledgeSource.create({
       data: {
@@ -156,7 +168,18 @@ knowledgeSourcesRouter.post(
       where: { slug: orgSlug },
       create: { slug: orgSlug, name: orgId ?? orgSlug },
       update: {},
+      select: { id: true, plan: true },
     });
+
+    const sourceCount = await prisma.knowledgeSource.count({ where: { organizationId: org.id } });
+    const limit = PLAN_LIMITS[org.plan].knowledgeSources;
+    if (sourceCount >= limit) {
+      res.status(403).json({
+        error: `Knowledge source limit reached (${limit} on ${org.plan} plan). Upgrade to add more.`,
+        code: 'LIMIT_EXCEEDED',
+      });
+      return;
+    }
 
     const source = await prisma.knowledgeSource.create({
       data: {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { Webhook } from 'svix';
+import Stripe from 'stripe';
 import { prisma, OrganizationRole } from '@app/database';
 import { getEnv } from '@app/shared';
 import crypto from 'crypto';
@@ -190,5 +191,96 @@ interface ClerkUserData {
     res.status(200).json({ success: true, received: eventType });
   } catch {
     res.status(500).json({ error: 'Failed to process webhook event' });
+  }
+});
+
+// POST /webhooks/stripe
+webhooksRouter.post('/stripe', async (req: CustomRequest, res: Response) => {
+  const env = getEnv();
+
+  if (!env.STRIPE_SECRET_KEY) {
+    res.status(500).json({ error: 'Stripe is not configured' });
+    return;
+  }
+
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY);
+  const sig = req.headers['stripe-signature'] as string | undefined;
+  const rawBody = req.rawBody ?? JSON.stringify(req.body);
+
+  let event: Stripe.Event;
+  try {
+    if (env.STRIPE_WEBHOOK_SECRET && sig) {
+      event = stripe.webhooks.constructEvent(rawBody, sig, env.STRIPE_WEBHOOK_SECRET);
+    } else {
+      event = JSON.parse(rawBody) as Stripe.Event;
+    }
+  } catch {
+    res.status(400).json({ error: 'Invalid Stripe webhook signature' });
+    return;
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const orgId = session.metadata?.['orgId'];
+        if (!orgId || !session.subscription) break;
+
+        const subscription = await stripe.subscriptions.retrieve(session.subscription as string);
+        const priceId = subscription.items.data[0]?.price.id;
+        const env2 = getEnv();
+
+        let plan: 'PRO' | 'ENTERPRISE' = 'PRO';
+        if (priceId === env2.STRIPE_ENTERPRISE_PRICE_ID) plan = 'ENTERPRISE';
+
+        // billing_cycle_anchor is the next renewal timestamp in Stripe SDK v22
+        const periodEnd = (subscription as unknown as Record<string, unknown>)['current_period_end'];
+        const currentPeriodEnd = typeof periodEnd === 'number' ? new Date(periodEnd * 1000) : null;
+
+        await prisma.organization.update({
+          where: { id: orgId },
+          data: { plan, stripeSubscriptionId: subscription.id, currentPeriodEnd },
+        });
+        break;
+      }
+
+      case 'customer.subscription.updated': {
+        const sub = event.data.object as Stripe.Subscription;
+        const org = await prisma.organization.findUnique({
+          where: { stripeSubscriptionId: sub.id },
+        });
+        if (!org) break;
+
+        const priceId = sub.items.data[0]?.price.id;
+        const env2 = getEnv();
+        let plan: 'PRO' | 'ENTERPRISE' = 'PRO';
+        if (priceId === env2.STRIPE_ENTERPRISE_PRICE_ID) plan = 'ENTERPRISE';
+
+        const periodEnd2 = (sub as unknown as Record<string, unknown>)['current_period_end'];
+        const currentPeriodEnd2 = typeof periodEnd2 === 'number' ? new Date(periodEnd2 * 1000) : null;
+
+        await prisma.organization.update({
+          where: { id: org.id },
+          data: { plan, currentPeriodEnd: currentPeriodEnd2 },
+        });
+        break;
+      }
+
+      case 'customer.subscription.deleted': {
+        const sub = event.data.object as Stripe.Subscription;
+        await prisma.organization.updateMany({
+          where: { stripeSubscriptionId: sub.id },
+          data: { plan: 'FREE', stripeSubscriptionId: null, currentPeriodEnd: null },
+        });
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    res.status(200).json({ received: true });
+  } catch {
+    res.status(500).json({ error: 'Failed to process Stripe webhook' });
   }
 });

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -3,6 +3,7 @@ import { Webhook } from 'svix';
 import Stripe from 'stripe';
 import { prisma, OrganizationRole } from '@app/database';
 import { getEnv } from '@app/shared';
+import { logger } from '../logger.js';
 import crypto from 'crypto';
 
 export const webhooksRouter: Router = Router();
@@ -220,20 +221,28 @@ webhooksRouter.post('/stripe', async (req: CustomRequest, res: Response) => {
   }
 
   try {
+    logger.info({ type: event.type }, 'stripe webhook received');
+
     switch (event.type) {
       case 'checkout.session.completed': {
         const session = event.data.object as Stripe.Checkout.Session;
         const orgId = session.metadata?.['orgId'];
-        if (!orgId || !session.subscription) break;
+        const subscriptionId = typeof session.subscription === 'string'
+          ? session.subscription
+          : (session.subscription as Stripe.Subscription | null)?.id ?? null;
 
-        const subscription = await stripe.subscriptions.retrieve(session.subscription as string);
+        logger.info({ orgId, subscriptionId }, 'checkout.session.completed');
+
+        if (!orgId || !subscriptionId) break;
+
+        const subscription = await stripe.subscriptions.retrieve(subscriptionId);
         const priceId = subscription.items.data[0]?.price.id;
-        const env2 = getEnv();
+        logger.info({ priceId, subscriptionId: subscription.id }, 'subscription retrieved');
 
+        const env2 = getEnv();
         let plan: 'PRO' | 'ENTERPRISE' = 'PRO';
         if (priceId === env2.STRIPE_ENTERPRISE_PRICE_ID) plan = 'ENTERPRISE';
 
-        // billing_cycle_anchor is the next renewal timestamp in Stripe SDK v22
         const periodEnd = (subscription as unknown as Record<string, unknown>)['current_period_end'];
         const currentPeriodEnd = typeof periodEnd === 'number' ? new Date(periodEnd * 1000) : null;
 
@@ -241,6 +250,7 @@ webhooksRouter.post('/stripe', async (req: CustomRequest, res: Response) => {
           where: { id: orgId },
           data: { plan, stripeSubscriptionId: subscription.id, currentPeriodEnd },
         });
+        logger.info({ orgId, plan }, 'organization plan updated');
         break;
       }
 
@@ -280,7 +290,8 @@ webhooksRouter.post('/stripe', async (req: CustomRequest, res: Response) => {
     }
 
     res.status(200).json({ received: true });
-  } catch {
+  } catch (err) {
+    logger.error({ err }, 'stripe webhook handler error');
     res.status(500).json({ error: 'Failed to process Stripe webhook' });
   }
 });

--- a/apps/web/src/app/dashboard/billing/loading.tsx
+++ b/apps/web/src/app/dashboard/billing/loading.tsx
@@ -1,0 +1,7 @@
+export default function BillingLoading() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/10 border-t-white/60" />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@clerk/nextjs';
+import { useSearchParams } from 'next/navigation';
+import { Zap, CheckCircle2, XCircle, Loader2, ExternalLink, CreditCard } from 'lucide-react';
+
+interface UsageStat {
+  used: number;
+  limit: number;
+}
+
+interface BillingStatus {
+  plan: 'FREE' | 'PRO' | 'ENTERPRISE';
+  currentPeriodEnd: string | null;
+  hasActiveSubscription: boolean;
+  usage: {
+    knowledgeSources: UsageStat;
+    conversationsThisMonth: UsageStat;
+  };
+}
+
+const PLANS = [
+  {
+    id: 'FREE' as const,
+    name: 'Free',
+    price: '$0',
+    period: 'forever',
+    features: ['3 knowledge sources', '100 conversations / month', 'Embeddable widget', 'Analytics'],
+  },
+  {
+    id: 'PRO' as const,
+    name: 'Pro',
+    price: '$29',
+    period: 'per month',
+    features: ['20 knowledge sources', '1,000 conversations / month', 'Custom AI persona', 'Domain whitelist', 'Priority support'],
+    highlight: true,
+  },
+  {
+    id: 'ENTERPRISE' as const,
+    name: 'Enterprise',
+    price: '$99',
+    period: 'per month',
+    features: ['Unlimited knowledge sources', 'Unlimited conversations', 'Everything in Pro', 'Dedicated support'],
+  },
+];
+
+function UsageBar({ label, stat }: { label: string; stat: UsageStat }) {
+  const isUnlimited = stat.limit === Infinity || stat.limit >= 999999;
+  const pct = isUnlimited ? 0 : Math.min((stat.used / stat.limit) * 100, 100);
+  const isWarning = pct >= 80;
+  const isFull = pct >= 100;
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between text-xs">
+        <span className="text-neutral-400">{label}</span>
+        <span className={isFull ? 'text-red-400' : isWarning ? 'text-amber-400' : 'text-neutral-500'}>
+          {stat.used.toLocaleString()} / {isUnlimited ? '∞' : stat.limit.toLocaleString()}
+        </span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+        {!isUnlimited && (
+          <div
+            className={`h-full rounded-full transition-all ${
+              isFull ? 'bg-red-500' : isWarning ? 'bg-amber-500' : 'bg-indigo-500'
+            }`}
+            style={{ width: `${pct}%` }}
+          />
+        )}
+        {isUnlimited && <div className="h-full w-full rounded-full bg-indigo-500/30" />}
+      </div>
+    </div>
+  );
+}
+
+export default function BillingPage() {
+  const { getToken } = useAuth();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<BillingStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [upgrading, setUpgrading] = useState<string | null>(null);
+  const [openingPortal, setOpeningPortal] = useState(false);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+  const success = searchParams.get('success');
+  const canceled = searchParams.get('canceled');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const token = await getToken();
+        const res = await fetch(`${apiUrl}/billing/status`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) setStatus((await res.json()) as BillingStatus);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, []);
+
+  const handleUpgrade = async (plan: 'PRO' | 'ENTERPRISE') => {
+    setUpgrading(plan);
+    try {
+      const token = await getToken();
+      const res = await fetch(`${apiUrl}/billing/create-checkout`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ plan }),
+      });
+      if (res.ok) {
+        const { url } = (await res.json()) as { url: string };
+        window.location.href = url;
+      }
+    } finally {
+      setUpgrading(null);
+    }
+  };
+
+  const handleManage = async () => {
+    setOpeningPortal(true);
+    try {
+      const token = await getToken();
+      const res = await fetch(`${apiUrl}/billing/create-portal`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const { url } = (await res.json()) as { url: string };
+        window.location.href = url;
+      }
+    } finally {
+      setOpeningPortal(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-8 animate-fade-in">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-white">Billing</h1>
+        <p className="mt-1 text-sm text-neutral-500">Manage your subscription and usage.</p>
+      </div>
+
+      {/* Success / canceled banners */}
+      {success && (
+        <div className="flex items-center gap-3 rounded-xl border border-green-500/20 bg-green-500/10 px-4 py-3 text-sm text-green-400">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          Subscription activated — your plan has been upgraded.
+        </div>
+      )}
+      {canceled && (
+        <div className="flex items-center gap-3 rounded-xl border border-neutral-700 bg-white/[0.03] px-4 py-3 text-sm text-neutral-400">
+          <XCircle className="h-4 w-4 shrink-0" />
+          Checkout was canceled. Your plan was not changed.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20 text-neutral-600">
+          <Loader2 className="h-6 w-6 animate-spin" />
+        </div>
+      ) : (
+        <>
+          {/* Current plan + usage */}
+          {status && (
+            <div className="glass rounded-2xl p-6">
+              <div className="mb-5 flex items-center justify-between">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-widest text-neutral-600">Current plan</p>
+                  <div className="mt-1 flex items-center gap-2">
+                    <span className="text-2xl font-semibold text-white">{status.plan}</span>
+                    {status.plan !== 'FREE' && (
+                      <span className="rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-medium text-indigo-400">
+                        Active
+                      </span>
+                    )}
+                  </div>
+                  {status.currentPeriodEnd && (
+                    <p className="mt-0.5 text-xs text-neutral-600">
+                      Renews {new Date(status.currentPeriodEnd).toLocaleDateString()}
+                    </p>
+                  )}
+                </div>
+
+                {status.hasActiveSubscription && (
+                  <button
+                    onClick={() => void handleManage()}
+                    disabled={openingPortal}
+                    className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-neutral-400 transition-colors hover:border-white/20 hover:text-white disabled:opacity-50"
+                  >
+                    {openingPortal ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+                    Manage subscription
+                    <ExternalLink className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+
+              <div className="space-y-4">
+                <UsageBar label="Knowledge sources" stat={status.usage.knowledgeSources} />
+                <UsageBar label="Conversations this month" stat={status.usage.conversationsThisMonth} />
+              </div>
+            </div>
+          )}
+
+          {/* Plan cards */}
+          <div>
+            <h2 className="mb-4 text-sm font-semibold text-white">Plans</h2>
+            <div className="grid gap-4 sm:grid-cols-3">
+              {PLANS.map((plan) => {
+                const isCurrent = status?.plan === plan.id;
+                const isDowngrade = status && ['PRO', 'ENTERPRISE'].indexOf(plan.id) < ['PRO', 'ENTERPRISE'].indexOf(status.plan);
+
+                return (
+                  <div
+                    key={plan.id}
+                    className={`relative flex flex-col rounded-2xl border p-5 ${
+                      plan.highlight
+                        ? 'border-indigo-500/40 bg-indigo-500/[0.06]'
+                        : 'border-white/[0.06] bg-white/[0.03]'
+                    } ${isCurrent ? 'ring-1 ring-white/20' : ''}`}
+                  >
+                    {plan.highlight && (
+                      <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 rounded-full border border-indigo-500/30 bg-indigo-600 px-3 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-white">
+                        Popular
+                      </span>
+                    )}
+
+                    <div className="mb-4">
+                      <p className="text-sm font-semibold text-white">{plan.name}</p>
+                      <div className="mt-1 flex items-baseline gap-1">
+                        <span className="text-2xl font-bold text-white">{plan.price}</span>
+                        <span className="text-xs text-neutral-600">{plan.period}</span>
+                      </div>
+                    </div>
+
+                    <ul className="mb-5 flex-1 space-y-2">
+                      {plan.features.map((f) => (
+                        <li key={f} className="flex items-center gap-2 text-xs text-neutral-400">
+                          <Zap className="h-3 w-3 shrink-0 text-indigo-500" />
+                          {f}
+                        </li>
+                      ))}
+                    </ul>
+
+                    {isCurrent ? (
+                      <div className="rounded-lg border border-white/10 py-2 text-center text-xs font-medium text-neutral-500">
+                        Current plan
+                      </div>
+                    ) : plan.id === 'FREE' || isDowngrade ? (
+                      <div className="rounded-lg border border-white/[0.06] py-2 text-center text-xs text-neutral-700">
+                        {plan.id === 'FREE' ? 'Downgrade via portal' : 'Manage in portal'}
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => void handleUpgrade(plan.id as 'PRO' | 'ENTERPRISE')}
+                        disabled={!!upgrading}
+                        className={`flex items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+                          plan.highlight
+                            ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+                            : 'border border-white/10 bg-white/[0.04] text-white hover:bg-white/[0.08]'
+                        }`}
+                      >
+                        {upgrading === plan.id && <Loader2 className="h-4 w-4 animate-spin" />}
+                        Upgrade to {plan.name}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Zap,
+  CreditCard,
 } from 'lucide-react';
 import { OrganizationSwitcher, UserButton } from '@clerk/nextjs';
 
@@ -20,6 +21,7 @@ const navigation = [
   { name: 'Knowledge Base', href: '/dashboard/knowledge-base', icon: Book },
   { name: 'Conversations', href: '/dashboard/conversations', icon: MessageSquare },
   { name: 'Analytics', href: '/dashboard/analytics', icon: BarChart2 },
+  { name: 'Billing', href: '/dashboard/billing', icon: CreditCard },
   { name: 'Settings', href: '/dashboard/settings', icon: Settings },
 ];
 

--- a/packages/database/prisma/migrations/20260804190409_add_stripe_billing_to_organization/migration.sql
+++ b/packages/database/prisma/migrations/20260804190409_add_stripe_billing_to_organization/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[stripeCustomerId]` on the table `organizations` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[stripeSubscriptionId]` on the table `organizations` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "currentPeriodEnd" TIMESTAMP(3),
+ADD COLUMN     "stripeCustomerId" TEXT,
+ADD COLUMN     "stripeSubscriptionId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organizations_stripeCustomerId_key" ON "organizations"("stripeCustomerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organizations_stripeSubscriptionId_key" ON "organizations"("stripeSubscriptionId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -38,6 +38,11 @@ model Organization {
   notifyOnHandoff      Boolean  @default(true)
   notifyOnNewConversation Boolean @default(false)
 
+  // Phase 8 — Stripe billing
+  stripeCustomerId     String?  @unique
+  stripeSubscriptionId String?  @unique
+  currentPeriodEnd     DateTime?
+
   memberships      Membership[]
   knowledgeSources KnowledgeSource[]
   conversations    Conversation[]

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -37,6 +37,9 @@ const envSchema = z.object({
 
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
+  STRIPE_PRO_PRICE_ID: z.string().optional(),
+  STRIPE_ENTERPRISE_PRICE_ID: z.string().optional(),
+  NEXT_PUBLIC_WEB_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       resend:
         specifier: ^6.18.1
         version: 6.18.1
+      stripe:
+        specifier: ^22.4.0
+        version: 22.4.0(@types/node@22.20.1)
       svix:
         specifier: ^1.99.1
         version: 1.99.1
@@ -2765,6 +2768,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.4.0:
+    resolution: {integrity: sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -5470,6 +5482,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.4.0(@types/node@22.20.1):
+    optionalDependencies:
+      '@types/node': 22.20.1
 
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Implements Phase 8 — full Stripe billing integration with plan-based usage limits and a billing dashboard.

- **Subscription plans** (Free / Pro / Enterprise) via Stripe Checkout — one-click upgrade flow
- **Usage limits** enforced at the API layer: knowledge sources and monthly conversations capped per plan
- **Stripe webhook handler** for `checkout.session.completed`, `subscription.updated`, and `subscription.deleted` — plan in DB updates automatically after payment
- **Customer Portal** integration — manage or cancel subscription from dashboard
- **Billing page** with current plan badge, usage bars with warning states, and plan comparison cards

## Changes

| Layer | File | What changed |
|---|---|---|
| DB schema | `packages/database/prisma/schema.prisma` | Added `stripeCustomerId`, `stripeSubscriptionId`, `currentPeriodEnd` to Organization |
| Migration | `prisma/migrations/...` | `add_stripe_billing_to_organization` |
| Env | `packages/shared/src/env.ts` | Added `STRIPE_PRO_PRICE_ID`, `STRIPE_ENTERPRISE_PRICE_ID`, `NEXT_PUBLIC_WEB_URL` |
| API | `apps/api/src/routes/billing.ts` | New `GET /billing/status`, `POST /billing/create-checkout`, `POST /billing/create-portal` |
| API | `apps/api/src/routes/webhooks.ts` | `POST /webhooks/stripe` — handles subscription lifecycle + structured logging |
| API | `apps/api/src/routes/knowledge-sources.ts` | Enforce knowledge source limit per plan before upload/website crawl |
| API | `apps/api/src/routes/chat.ts` | Enforce monthly conversation limit per plan before creating new conversation |
| API | `apps/api/src/app.ts` | Register `/billing` router |
| Web | `apps/web/src/app/dashboard/billing/page.tsx` | Billing dashboard — plan cards, usage bars, Stripe Checkout + Portal flow |
| Web | `apps/web/src/components/Sidebar.tsx` | Add Billing link to navigation |

## Plan limits

| | Free | Pro | Enterprise |
|---|---|---|---|
| Knowledge sources | 3 | 20 | Unlimited |
| Conversations / month | 100 | 1,000 | Unlimited |

## Test plan

- [ ] Billing page loads with correct plan (FREE by default)
- [ ] Usage bars reflect real counts vs plan limits
- [ ] Click Upgrade to Pro → Stripe Checkout opens → pay with `4242 4242 4242 4242` → redirected back → plan shows PRO
- [ ] `stripe listen` terminal shows `checkout.session.completed [200]`
- [ ] Manage subscription → Stripe Customer Portal opens
- [ ] Cancel subscription via portal → plan reverts to FREE
- [ ] Upload more than 3 knowledge sources on Free plan → 403 with upgrade message
- [ ] Start more than 100 conversations/month on Free plan → 403 with upgrade message